### PR TITLE
make thumbnails accessible so that images can be added dynamically

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -24,7 +24,7 @@ function Lightbox () {
 		currThumbnail = false, // first clicked thumbnail
 		currImage = {}, // currently shown image
 		currImages = [], // images belonging to current group
-		thumbnails = [], // thumbnails
+		//thumbnails = [], // thumbnails
 		isOpen = false, // check if box is open
 		loadingImgSrc, // path to loading image
 		animationEl, // reference to animation-element
@@ -48,6 +48,7 @@ function Lightbox () {
 	CTX.opt = {}
 	CTX.box = false
 	CTX.wrapper = false
+	CTX.thumbnails = []
 
 	/**
 	 * Private methods
@@ -188,9 +189,9 @@ function Lightbox () {
 	 */
 	function getByGroup(group) {
 		var arr = []
-		for (var i = 0; i < thumbnails.length; i++) {
-			if(getAttr(thumbnails[i],'data-jslghtbx-group') === group) {
-				arr.push(thumbnails[i])
+		for (var i = 0; i < CTX.thumbnails.length; i++) {
+			if(getAttr(CTX.thumbnails[i],'data-jslghtbx-group') === group) {
+				arr.push(CTX.thumbnails[i])
 			}
 		}
 		return arr
@@ -612,7 +613,7 @@ function Lightbox () {
 		for(var i = 0; i < arr.length; i++)
 		{
 			if(hasAttr(arr[i],'data-jslghtbx')) {
-				thumbnails.push(arr[i])
+				CTX.thumbnails.push(arr[i])
 				clckHlpr(arr[i])
 			}
 		}


### PR DESCRIPTION
this patch will make thumbnails (which is used for grouping images) accessible so whenever a image element loaded dynamically, one can push that image element to this array. 

like this,

var dynamicpic = createDynamicImageElementFromUrl('//somewhere.ext/some/image');
lightbox.thumbnails.push(dynamicpic);
dynamicpic.addEventListener('click', function(e) { lightbox.open(this); });