### PR TITLE
Add CSS class to enable fallback links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ If you want to use captions add the `data-jslghtbx-caption` attribute. You can a
 	
 	<img class="jslghtbx-thmb" src="img/lightbox/2.jpg" alt="" data-jslghtbx data-jslghtbx-caption="This is my <a href='http://abc.de'>caption.</a>">
 
+To allow e.g. "Open in background"-actions and non-JavaScript-enabled browsing to work as expected, an image can be wrapped in a link element with the CSS-class `jslghtbx-fallback-link` applied. A "left-click" on the image in a JavaScript-enabled browser will trigger the lightbox and not the `href`-action, though still unobtrusively handling other cases.
+
+	<a class="jslghtbx-fallback-link" href="img/1-big.jpg"><img class="jslghtbx-thmb" src="img/lightbox/1.jpg" alt="" data-jslghtbx="img/1-big.jpg"></a>
+
 ## CSS Animations
 
 When the lightbox is opened first, the image inside gets the class `jslghtbx-animate-init`. This is useful if you want to animate opacity. 

--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -625,6 +625,15 @@ function Lightbox () {
       }
     }
 
+    // Deactivate wrapping "no JS"-fallback links if we reach this point.
+    var noJsHref = document.getElementsByClassName('jslghtbx-fallback-link');
+    for (var i = 0; i < noJsHref.length; i++) {
+      // Using an event listener instead of
+      //     noJsHref[i].href = 'javascript:void(0);';
+      // allows e.g. "Open in background"-actions to function correctly.
+      noJsHref[i].addEventListener('click', function (e) { e.preventDefault(); });
+    }
+
   }
 
   /**


### PR DESCRIPTION
Adding the class `jslghtbx-fallback-link` to a surrounding link element will now still trigger the Lightbox on click, but also allow a fallback mechanism for non-JavaScript-enabled browsing to still present those
users with a link to e.g. the full-size image. It also enables the expected actions for both JS and non-JS browsing when e.g. middle-clicking to open the full-size link in the background and such.

The chosen approach can certainly be discussed, but I wanted the function myself, so I might as well lift the issue upstream with a sample implementation.

---

Side-note: I see that minified files were recently added to the repository. That makes it easier for people to just clone and directly use minified files, but it also makes pull requests a bit "incomplete" without regenerating those, which opens up a couple of issues (tools used, settings, test suites, etc.). This pull request does not include a regenerated minified file.