### PR TITLE
Extend push method for thumbnails attribute

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -683,7 +683,6 @@ function Lightbox() {
         for (var i = 0; i < arr.length; i++) {
             if (hasAttr(arr[i], 'data-jslghtbx')) {
                 CTX.thumbnails.push(arr[i]);
-                clckHlpr(arr[i]);
             }
         }
 
@@ -854,5 +853,14 @@ function Lightbox() {
             CTX.opt.onclose();
         }
     };
-}
 
+    /**
+     * Extends thumbnails.push to add click handlers to dynamically loaded thumbs
+     */
+    CTX.thumbnails.push = function (){
+        for( var i = 0, l = arguments.length; i < l; i++ ) {
+            clckHlpr(arguments[i]);
+        }
+        return Array.prototype.push.apply(this,arguments);
+    };
+}


### PR DESCRIPTION
Extend `push` method for thumbnails attribute.
I did this because, when you dinamically load images, the actual
implementation only add the images to the lightbox... and not
add the click handlers to the extra images.

So, in my case (for explaining a real one), I have a gallery,
populated with thumbnails, that has infinite scroll. New thumbnails
are fetched via AJAX and displayed in the gallery and, when fetched,
I update the lightbox with `lightbox.thumbnail.push`, but... that only
updates the images that are showed in the lightbox.

If I want to display the lightbox clicking in one of the new fetched
images, it won't work... because they haven't handlers attached to the
click event. So, I had to rerun `lightbox.load()` every time
I fetched a new page of images. That doesn't seem the correct
way and even more, that's against the documentation of
`lightbox.load()`:

> Has to be called once on the box-object

So, I did this. It's simple and works. And only affects to the
`lightbox.thumbnails` attribute.

Maybe it should (or could) be done differently, I don't know.
What do you think about it? The only thing I know is that
to be forced to call `lightbox.load()` every time I fetch
a new bunch of images doesn't seems the correct way.

I also wasn't so sure where to place it, so I placed at the
end of the script, in **Public methods**.

**Note**: obviously, minified version should also change. I not touched it just in case you want to minify it in some specific way.
